### PR TITLE
GetFInfo: initialize ioFRefNum

### DIFF
--- a/custom/glue.c
+++ b/custom/glue.c
@@ -427,6 +427,7 @@ pascal OSErr GetFInfo(ConstStr255Param fileName, short vRefNum,
     pb.fileParam.ioVRefNum = vRefNum;
     pb.fileParam.ioNamePtr = (StringPtr)fileName;
     pb.fileParam.ioFVersNum = 0;
+    pb.fileParam.ioFDirlndex = 0;
     err = PBGetFInfoSync(&pb);
     *fndrInfo = pb.fileParam.ioFlFndrInfo;
     return err;


### PR DESCRIPTION
According to Inside Macintosh Volume (IV-148/149) this field must be set to 0 in order to use the name in ioNamePtr.

In my project I noticed that GetFInfo was unreliable. I think this is the cause.

Note: This is not the fix I'm using locally. I actually am using this:
```
static OSErr GetFInfo_fixed(ConstStr255Param fileName, short vRefNum,
    FInfo *fndrInfo) {
    ParamBlockRec pb = {
        .fileParam.ioVRefNum = vRefNum,
        .fileParam.ioNamePtr = (StringPtr)fileName,
    };
    OSErr err;
    err = PBGetFInfoSync(&pb);
    *fndrInfo = pb.fileParam.ioFlFndrInfo;
    return err;
}
```
That style of initialization causes ALL other fields to be zero-initialized, according to my understanding of C. However, it may be less compatible with older compilers and/or generate more code.